### PR TITLE
New gs-cog library structure

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -118,10 +118,13 @@
         </dependency>
         <dependency>
           <groupId>org.geoserver.community</groupId>
-          <artifactId>gs-cog</artifactId>
-          <!-- <version>${geoserver.version}</version> -->
-          <!-- FIXME: 2.25.2 not available yet -->
-          <version>2.25.1</version>
+          <artifactId>gs-cog-core</artifactId>
+          <version>${geoserver.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.geoserver.community</groupId>
+          <artifactId>gs-cog-http</artifactId>
+          <version>${geoserver.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
At the same time as the security bump to 2.25.2 the COG support split into a -core plugin and -* plugins for each supported transport (http, s3 etc).  I missed this at the time so had pinned gs-cog to an earlier version.  This rectifies that.